### PR TITLE
Remove cl-markup and emit attributes

### DIFF
--- a/src/emitter.lisp
+++ b/src/emitter.lisp
@@ -6,17 +6,34 @@
   (:documentation "Emit HTML5 from a CommonDoc document."))
 (in-package :common-html.emitter)
 
-;;; Utilities
+;;; Variables
 
-(defmacro html (&rest body)
-  "A wrapper around cl-markup's `markup` macro which works better in recursive
-contexts."
-  `(progn
-     (markup:markup ,@body)
-     nil))
+(defvar *output-stream* nil
+  "The stream the HTML will be written to.")
 
 (defvar *section-depth*
   "The depth of `section` classes. Used to produce header numbers, e.g. `h1, `h3`.")
+
+;;; Utilities
+
+(defun print-attribute (key value)
+  (format *output-stream* " ~A=~S" key value))
+
+(defun emit-metadata (hash-table)
+  (loop for key being the hash-keys of hash-table
+        for value being the hash-values of hash-table
+        do
+           (print-attribute key value)))
+
+(defmacro with-tag ((tag-name node &optional attributes) &rest body)
+  `(let ((tag-name ,tag-name))
+     (format *output-stream* "<~A" tag-name)
+     (emit-metadata (metadata ,node))
+     (loop for attribute in ,attributes do
+       (print-attribute (first attribute) (rest attribute)))
+     (write-string ">" *output-stream*)
+     ,@body
+     (format *output-stream* "</~A>" tag-name)))
 
 ;;; Emit methods
 
@@ -27,103 +44,116 @@ contexts."
   "Emit a list."
   (loop for elem in list do (emit elem)))
 
-(defmacro define-emitter (class &rest body)
+(defmacro define-emitter ((node class) &rest body)
   "Define an emitter method."
   `(defmethod emit ((node ,class))
      ,@body))
 
-(defmacro define-child-emitter (class &rest tag)
-  "Define a simple emitter for elements with `children`."
-  `(define-emitter ,class
-       (html (,@tag (emit (children node))))))
+(defmacro define-simple-emitter (class tag-name)
+  "Define a simple emitter."
+  `(define-emitter (node ,class)
+       (with-tag (,tag-name node)
+         (emit (children node)))))
 
-(define-emitter content-node
+(define-emitter (node content-node)
   "The generic emitter for content nodes."
   (loop for child in (children node) do
     (emit child)))
 
-(define-emitter text-node
-    (progn
-      (write-string (text node) markup:*output-stream*)
-      nil))
+(define-emitter (node text-node)
+    (if (metadata node)
+        (with-tag ("span" node)
+          (write-string (text node) *output-stream*))
+        (write-string (text node) *output-stream*)))
 
-(define-child-emitter paragraph :p)
-(define-child-emitter bold :b)
-(define-child-emitter italic :i)
-(define-child-emitter underline :u)
-(define-child-emitter strikethrough :strike)
-(define-child-emitter code :code)
-(define-child-emitter superscript :sup)
-(define-child-emitter subscript :sub)
+(define-simple-emitter paragraph "p")
+(define-simple-emitter bold "b")
+(define-simple-emitter italic "i")
+(define-simple-emitter underline "u")
+(define-simple-emitter strikethrough "strike")
+(define-simple-emitter code "code")
+(define-simple-emitter superscript "sup")
+(define-simple-emitter subscript "sub")
 
-(define-child-emitter code-block
-  :code :language (language node))
+(define-emitter (code code-block)
+  (with-tag ("code" code (list (cons "language"
+                                     (language code))))
+    (emit (children code))))
 
-(define-child-emitter inline-quote :q)
-(define-child-emitter block-quote :blockquote)
+(define-simple-emitter inline-quote "q")
+(define-simple-emitter block-quote "blockquote")
 
-(define-child-emitter document-link
-  :a :href (let ((sec-ref (section-reference node))
-                 (doc-ref (document-reference node)))
-             (if doc-ref
-                 (format nil "~A.html/#~A" doc-ref sec-ref)
-                 (format nil "#~A" sec-ref))))
+(define-child-emitter (ref document-link)
+  (let* ((sec-ref (section-reference ref))
+         (doc-ref (document-reference ref))
+         (url (if doc-ref
+                  (format nil "~A.html/#~A" doc-ref sec-ref)
+                  (format nil "#~A" sec-ref))))
+    (with-tag ("a" ref
+                   (list (cons "href" url)))
+      (emit (children ref)))))
 
-(define-child-emitter web-link
-  :a :href (quri:render-uri (uri node)))
+(define-child-emitter (link web-link)
+  (with-tag ("a" link (list (cons "href"
+                                  (quri:render-uri (uri node)))))
+    (emit (children link))))
 
-(define-child-emitter list-item :li)
+(define-simple-emitter list-item "li")
 
 (define-emitter definition
   (html (:dt (emit (term node)))
         (:dd (emit (definition node)))))
 
-(define-child-emitter unordered-list :ul)
-(define-child-emitter ordered-list :ol)
-(define-child-emitter definition-list :dl)
+(define-simple-emitter unordered-list "ul")
+(define-simple-emitter ordered-list "ol")
+(define-simple-emitter definition-list "dl")
 
-(define-emitter image
-    (html (:img :src (source node)
-                :alt (description node)
-                :title (description node))))
+(define-emitter (image image)
+  (with-tag ("img" image
+                   (list (cons "src" (source node))
+                         (cons "alt" (description node))
+                         (cons "title" (description node))))))
 
 (define-emitter figure
   (html (:figure
          (emit (image node))
          (:figcaption (emit (description node))))))
 
-(define-emitter table
-    (html (:table (emit (rows node)))))
+(define-emitter (table table)
+    (with-tag ("table" table)
+      (emit (rows table))))
 
-(define-emitter row
-    (html (:tr (emit (cells node)))))
+(define-emitter (row row)
+    (with-tag ("tr" row)
+      (emit (cells row))))
 
-(define-child-emitter cell :td)
+(define-simple-emitter cell "td")
 
-(define-emitter section
+(define-emitter (section section)
   (macrolet ((section-emitter (tag)
                `(progn
-                  (html (,tag (emit (title node))))
+                  (with-tag (,tag section)
+                    (emit (title section)))
                   (incf *section-depth*)
                   (if (slot-boundp node 'children)
-                      (emit (children node)))
+                      (emit (children section)))
                   (decf *section-depth*))))
     (case *section-depth*
-      (1 (section-emitter :h1))
-      (2 (section-emitter :h2))
-      (3 (section-emitter :h3))
-      (4 (section-emitter :h4))
-      (5 (section-emitter :h5))
-      (6 (section-emitter :h6))
-      (t (section-emitter :h6)))))
+      (1 (section-emitter "h1"))
+      (2 (section-emitter "h2"))
+      (3 (section-emitter "h3"))
+      (4 (section-emitter "h4"))
+      (5 (section-emitter "h5"))
+      (6 (section-emitter "h6"))
+      (t (section-emitter "h6")))))
 
-(define-emitter document
-    (progn
+(define-emitter (doc document)
+  (progn
       (markup:html5
        (:head
-        (:title (title node)))
+        (:title (title doc)))
        (:body
-        (emit (children node))))
+        (emit (children doc))))
       nil))
 
 (defun node-to-stream (node stream)
@@ -135,6 +165,6 @@ contexts."
 (defun node-to-html-string (node)
   "Return an HTML string from a node."
   (with-output-to-string (stream)
-    (let ((markup:*output-stream* stream)
+    (let ((*output-stream* stream)
           (*section-depth* 1))
       (emit node))))

--- a/t/common-html.lisp
+++ b/t/common-html.lisp
@@ -7,8 +7,10 @@
 
 ;;; Utils
 
-(defun emit-equal (node string)
-  (equal (common-html.emitter:node-to-html-string node) string))
+(defmacro emit-equal (node string)
+  `(is
+    (equal (common-html.emitter:node-to-html-string ,node)
+           ,string)))
 
 (defun mk-text (string)
   (doc text-node (:text string)))
@@ -23,124 +25,110 @@
 (in-suite tests)
 
 (test text
-  (is-true
-   (emit-equal (mk-text "test") "test")))
+  (emit-equal (mk-text "test") "test"))
 
 (test paragraph
-  (is-true
-   (emit-equal (doc
-                paragraph
-                ()
-                (text-node
-                 (:text "test")))
-               "<p>test</p>")))
+  (emit-equal (doc
+               paragraph
+               ()
+               (text-node
+                (:text "test")))
+              "<p>test</p>"))
 
 (test markup
-  (is-true
-   (emit-equal (doc
-                bold
+  (emit-equal (doc
+               bold
+               ()
+               (text-node
+                (:text "test")))
+              "<b>test</b>")
+  (emit-equal (doc
+               italic
+               ()
+               (text-node
+                (:text "test")))
+              "<i>test</i>")
+  (emit-equal (doc
+               underline
+               ()
+               (text-node
+                (:text "test")))
+              "<u>test</u>")
+  (emit-equal (doc
+               strikethrough
+               ()
+               (text-node
+                (:text "test")))
+              "<strike>test</strike>")
+  (emit-equal (doc
+               code
+               ()
+               (text-node
+                (:text "test")))
+              "<code>test</code>")
+  (emit-equal (doc
+               superscript
+               ()
+               (text-node
+                (:text "test")))
+              "<sup>test</sup>")
+  (emit-equal (doc
+               subscript
+               ()
+               (text-node
+                (:text "test")))
+              "<sub>test</sub>")
+  (emit-equal (doc
+               bold
+               ()
+               (italic
                 ()
-                (text-node
-                 (:text "test")))
-               "<b>test</b>"))
-  (is-true
-   (emit-equal (doc
-                italic
-                ()
-                (text-node
-                 (:text "test")))
-               "<i>test</i>"))
-  (is-true
-   (emit-equal (doc
-                underline
-                ()
-                (text-node
-                 (:text "test")))
-               "<u>test</u>"))
-  (is-true
-   (emit-equal (doc
-                strikethrough
-                ()
-                (text-node
-                 (:text "test")))
-               "<strike>test</strike>"))
-  (is-true
-   (emit-equal (doc
-                code
-                ()
-                (text-node
-                 (:text "test")))
-               "<code>test</code>"))
-  (is-true
-   (emit-equal (doc
-                superscript
-                ()
-                (text-node
-                 (:text "test")))
-               "<sup>test</sup>"))
-  (is-true
-   (emit-equal (doc
-                subscript
-                ()
-                (text-node
-                 (:text "test")))
-               "<sub>test</sub>"))
-  (is-true
-   (emit-equal (doc
-                bold
-                ()
-                (italic
+                (underline
                  ()
-                 (underline
-                  ()
-                  (text-node
-                   (:text "test")))))
-               "<b><i><u>test</u></i></b>")))
+                 (text-node
+                  (:text "test")))))
+              "<b><i><u>test</u></i></b>"))
 
 (test link
   (let ((uri "http://example.com/"))
-    (is-true
-     (emit-equal (doc
-                  web-link
-                  (:uri (quri:uri uri))
-                  (text-node
-                   (:text "test")))
-                 (format nil "<a href=\"~A\">test</a>" uri)))))
+    (emit-equal (doc
+                 web-link
+                 (:uri (quri:uri uri))
+                 (text-node
+                  (:text "test")))
+                (format nil "<a href=\"~A\">test</a>" uri))))
 
 (test list
-  (is-true
-   (emit-equal (doc
-                unordered-list
-                (:children (list
-                            (mk-text-item "1")
-                            (mk-text-item "2")
-                            (mk-text-item "3"))))
-               "<ul><li>1</li><li>2</li><li>3</li></ul>"))
-  (is-true
-   (emit-equal (doc
-                ordered-list
-                (:children (list
-                            (mk-text-item "1")
-                            (mk-text-item "2")
-                            (mk-text-item "3"))))
-               "<ol><li>1</li><li>2</li><li>3</li></ol>"))
-  (is-true
-   (emit-equal (doc
-                definition-list
-                (:children (list
-                            (doc
-                             definition
-                             (:term (mk-text "a")
-                              :definition (mk-text "1")))
-                            (doc
-                             definition
-                             (:term (mk-text "b")
-                              :definition (mk-text "2")))
-                            (doc
-                             definition
-                             (:term (mk-text "c")
-                              :definition (mk-text "3"))))))
-               "<dl><dt>a</dt><dd>1</dd><dt>b</dt><dd>2</dd><dt>c</dt><dd>3</dd></dl>")))
+  (emit-equal (doc
+               unordered-list
+               (:children (list
+                           (mk-text-item "1")
+                           (mk-text-item "2")
+                           (mk-text-item "3"))))
+              "<ul><li>1</li><li>2</li><li>3</li></ul>")
+  (emit-equal (doc
+               ordered-list
+               (:children (list
+                           (mk-text-item "1")
+                           (mk-text-item "2")
+                           (mk-text-item "3"))))
+              "<ol><li>1</li><li>2</li><li>3</li></ol>")
+  (emit-equal (doc
+               definition-list
+               (:children (list
+                           (doc
+                            definition
+                            (:term (mk-text "a")
+                             :definition (mk-text "1")))
+                           (doc
+                            definition
+                            (:term (mk-text "b")
+                             :definition (mk-text "2")))
+                           (doc
+                            definition
+                            (:term (mk-text "c")
+                             :definition (mk-text "3"))))))
+              "<dl><dt>a</dt><dd>1</dd><dt>b</dt><dd>2</dd><dt>c</dt><dd>3</dd></dl>"))
 
 (test image
   (let* ((src "fig.jpg")
@@ -150,9 +138,8 @@
            image
            (:source src
             :description desc))))
-    (is-true
-     (emit-equal document
-                 (format nil "<img src=~S alt=~S title=~S />" src desc desc)))))
+    (emit-equal document
+                (format nil "<img src=~S alt=~S title=~S />" src desc desc))))
 
 (test figure
   (let* ((src "fig.jpg")
@@ -166,11 +153,10 @@
                     (:source src
                      :description desc))
             :description (mk-text figdesc)))))
-    (is-true
-     (emit-equal document
-                 (format nil
-                         "<figure><img src=~S alt=~S title=~S /><figcaption>~A</figcaption></figure>"
-                         src desc desc figdesc)))))
+    (emit-equal document
+                (format nil
+                        "<figure><img src=~S alt=~S title=~S /><figcaption>~A</figcaption></figure>"
+                        src desc desc figdesc))))
 
 (test table
   (let* ((matrix
@@ -178,19 +164,18 @@
              (4 5 6)
              (7 8 9)))
          (document
-          (doc
-           table
-           (:rows
-            (loop for row in matrix collecting
-             (doc
-              row
-              (:cells
-               (loop for n in row collecting
-                (doc cell () (text-node (:text (write-to-string n))))))))))))
-    (is-true
-     (emit-equal document
-                 (format nil "<table>~{<tr>~{<td>~A</td>~}</tr>~}</table>"
-                         matrix)))))
+           (doc
+            table
+            (:rows
+             (loop for row in matrix collecting
+               (doc
+                row
+                (:cells
+                 (loop for n in row collecting
+                   (doc cell () (text-node (:text (write-to-string n))))))))))))
+    (emit-equal document
+                (format nil "<table>~{<tr>~{<td>~A</td>~}</tr>~}</table>"
+                        matrix))))
 
 (test section
   (let ((document
@@ -203,13 +188,12 @@
              (:title (mk-text "Sec 1.1.1"))))
            (section
             (:title (mk-text "Sec 1.2"))))))
-    (is-true
-     (emit-equal document
-                 (format nil "~{~A~}"
-                         (list "<h1>Sec 1</h1>"
-                               "<h2>Sec 1.1</h2>"
-                               "<h3>Sec 1.1.1</h3>"
-                               "<h2>Sec 1.2</h2>"))))))
+    (emit-equal document
+                (format nil "~{~A~}"
+                        (list "<h1>Sec 1</h1>"
+                              "<h2>Sec 1.1</h2>"
+                              "<h3>Sec 1.1.1</h3>"
+                              "<h2>Sec 1.2</h2>")))))
 
 (test document
   (let ((document
@@ -218,8 +202,7 @@
            (:title "My Title")
            (text-node
             (:text "test")))))
-    (is-true
-     (emit-equal document
-                 "<!DOCTYPE html><html><head><title>My Title</title></head><body>test</body></html>"))))
+    (emit-equal document
+                "<!DOCTYPE html><html><head><title>My Title</title></head><body>test</body></html>")))
 
 (run! 'tests)

--- a/t/common-html.lisp
+++ b/t/common-html.lisp
@@ -139,7 +139,7 @@
            (:source src
             :description desc))))
     (emit-equal document
-                (format nil "<img src=~S alt=~S title=~S />" src desc desc))))
+                (format nil "<img src=~S alt=~S title=~S/>" src desc desc))))
 
 (test figure
   (let* ((src "fig.jpg")
@@ -155,7 +155,7 @@
             :description (mk-text figdesc)))))
     (emit-equal document
                 (format nil
-                        "<figure><img src=~S alt=~S title=~S /><figcaption>~A</figcaption></figure>"
+                        "<figure><img src=~S alt=~S title=~S/><figcaption>~A</figcaption></figure>"
                         src desc desc figdesc))))
 
 (test table
@@ -203,6 +203,6 @@
            (text-node
             (:text "test")))))
     (emit-equal document
-                "<!DOCTYPE html><html><head><title>My Title</title></head><body>test</body></html>")))
+                "<html><head><title>My Title</title></head><body>test</body></html>")))
 
 (run! 'tests)


### PR DESCRIPTION
This branch replaces [cl-markup](https://github.com/arielnetworks/cl-markup) with custom code that makes it easier to emit node attributes, and does just that.
