### PR TITLE
Use &body instead of &rest to let Emacs do a proper indentation.

### DIFF
--- a/src/emitter.lisp
+++ b/src/emitter.lisp
@@ -56,7 +56,7 @@
   "Emit a list."
   (loop for elem in list do (emit elem)))
 
-(defmacro define-emitter ((node class) &rest body)
+(defmacro define-emitter ((node class) &body body)
   "Define an emitter method."
   `(defmethod emit ((,node ,class))
      ,@body))


### PR DESCRIPTION
With `&rest` we get this indentation:

```lisp
(define-emitter (obj page)
                "Emit an piece of documentation."
                (let ((toc (make-page-toc obj)))
                  (with-html
                    (:html
                     (:head
                      (:meta :name "viewport"
                             :content "width=device-width, initial-scale=1")
                      (:title "Example page")
```

With `&body`:

```lisp
(define-emitter (obj page)
  "Emit an piece of documentation."
  (let ((toc (make-page-toc obj)))
    (with-html
      (:html
       (:head
        (:meta :name "viewport"
               :content "width=device-width, initial-scale=1")
        (:title "Example page")
```